### PR TITLE
user.Id property removed

### DIFF
--- a/src/User_Authentication/Controllers/OrderController.cs
+++ b/src/User_Authentication/Controllers/OrderController.cs
@@ -40,7 +40,7 @@ namespace User_Authentication.Controllers
         public async Task<IActionResult> Confirm()
         {
             var user = await GetCurrentUserAsync();
-            var activeOrder = await context.Order.Where(o => o.DateCompleted == null && o.User.Id == user.Id).SingleOrDefaultAsync();
+            var activeOrder = await context.Order.Where(o => o.DateCompleted == null && o.User == user).SingleOrDefaultAsync();
             activeOrder.DateCompleted = DateTime.Today;
             context.Update(activeOrder);
             await context.SaveChangesAsync();
@@ -65,7 +65,7 @@ namespace User_Authentication.Controllers
         public async Task<IActionResult> Cart()
         {
             var user = await GetCurrentUserAsync();
-            var activeOrder = await context.Order.Where(o => o.DateCompleted == null && o.User.Id == user.Id).SingleOrDefaultAsync();
+            var activeOrder = await context.Order.Where(o => o.DateCompleted == null && o.User == user).SingleOrDefaultAsync();
             Console.WriteLine(activeOrder);
             OrderViewModel model = new OrderViewModel(context, user);
 

--- a/src/User_Authentication/Models/ManageViewModels/ApplicationUser.cs
+++ b/src/User_Authentication/Models/ManageViewModels/ApplicationUser.cs
@@ -28,6 +28,10 @@ namespace User_Authentication.Models
 
         public ICollection<Product> Products;
         public ICollection<Order> Orders;
+        public ICollection<LineItem> LineItems;
+
+
+
 
     }
 }


### PR DESCRIPTION
User.Id is no longer used to filter products in the database by current user; instead, the user object itself coerces to user.Id where needed.

To test:

1. Git fetch
2. Git checkout es-remove-user-id
3. Ensure that methods in order controller user the "user" object only to cycle through products in database
4. Be sure app still runs as intended